### PR TITLE
Add syntax check for Lua files with Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: c
+
+install:
+  - sudo apt-get install lua5.2
+
+script:
+  - luac -p mediawiki.lrdevplugin/*.lua


### PR DESCRIPTION
This adds a Travis-CI build which will run luac on the Lua files.
luac will try to parse the Lua files and report syntax errors.

See [Travis-CI build](https://travis-ci.org/JeanFred/LrMediaWiki/builds/50782639)

Nothing revolutionary but might be useful to catch errors when committing and to test Pull requests.